### PR TITLE
Show debug UI elements after loading completes

### DIFF
--- a/amica/src/components/loadingProgress.tsx
+++ b/amica/src/components/loadingProgress.tsx
@@ -128,7 +128,7 @@ export function LoadingProgress() {
     <>
       {/* Main loading bar overlay */}
       {loadingStage && (
-        <div className="fixed inset-0 flex items-center justify-center bg-gradient-to-br from-white via-gray-50 to-gray-100 z-50 p-4" style={{ fontFamily: 'Fredoka, sans-serif' }}>
+        <div className="fixed inset-0 flex items-center justify-center bg-gradient-to-br from-white via-gray-50 to-gray-100 z-[9999] p-4" style={{ fontFamily: 'Fredoka, sans-serif' }}>
           <div className="w-full max-w-[600px] px-4 sm:px-8">
             {/* Stage text - larger on mobile */}
             <div className="text-gray-800 text-xl sm:text-2xl md:text-3xl mb-4 sm:mb-6 text-center font-bold tracking-wide">

--- a/amica/src/features/scene3d/DebugSystem.ts
+++ b/amica/src/features/scene3d/DebugSystem.ts
@@ -44,6 +44,7 @@ export class DebugSystem {
     // Initialize GUI
     this.gui = new GUI();
     this.gui.domElement.style.marginTop = "56px";
+    this.gui.domElement.style.display = "none"; // Hidden initially, shown after loading
 
     // Initialize Stats
     this.stats = new Stats();
@@ -52,6 +53,7 @@ export class DebugSystem {
     this.stats.dom.style.position = "absolute";
     this.stats.dom.style.top = "56px";
     this.stats.dom.style.left = window.innerWidth - 80 + "px";
+    this.stats.dom.style.display = "none"; // Hidden initially, shown after loading
     document.body.appendChild(this.stats.dom);
 
     // Setup stats panels

--- a/amica/src/utils/fileLoadingProgress.ts
+++ b/amica/src/utils/fileLoadingProgress.ts
@@ -30,5 +30,13 @@ export function completeLoading() {
   if (typeof window !== "undefined") {
     (<any>window).chatvrm_loading_stage = null;
     (<any>window).chatvrm_loading_stage_cnt++;
+
+    // Show debug UI elements when loading completes
+    const statsElements = document.querySelectorAll('.stats-js, .lil-gui');
+    statsElements.forEach((el) => {
+      if (el instanceof HTMLElement) {
+        el.style.display = 'block';
+      }
+    });
   }
 }


### PR DESCRIPTION
- Hide debug GUI and stats panels initially during load
- Reveal both elements once file loading finishes
- Increase z-index of loading overlay to ensure proper stacking